### PR TITLE
Updates to dub.json for windows build support, README tweaks for newbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ will launch a benchmark, and should be enough to convine one of the functionalit
 ## Example
 
 ```D
-import rocksdb;
-import std.conv : to;
-
 auto opts = new DBOptions;
 opts.createIfMissing = true;
 opts.errorIfExists = false;
@@ -29,25 +26,26 @@ opts.errorIfExists = false;
 auto db = new Database(opts, "testdb");
 
 // Put a value into the database
-db.put("key", "value");
+db.putString("key", "value");
 
 // Get a value out
-assert(db.get("key") == "value");
+assert(db.getString("key") == "value");
 
+ubyte[] key = ['\x00', '\x00'];
 // Delete a value
-db.remove("key");
+db.remove(key);
 
 // Add values in bulk
 auto batch = new WriteBatch;
 for (int i = 0; i < 1000; i++) {
-  batch.put(i.to!string, i.to!string);
+batch.putString(i.to!string, i.to!string);
 }
 db.write(batch);
 
 // Iterate over the DB
 auto iter = db.iter();
 foreach (key, value; iter) {
-  db.remove(key);
+db.remove(key);
 }
 destroy(iter);
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@ A straightforward binding to RocksDB v5.0.1 in D-lang.
 
 ## Building
 
-You need a valid rocksdb library somewhere your linker can find it.
+You need a valid rocksdb library in the root of this project so your linker can find it.  It is recommended to use a recent version of rocksdb, tested with 
+
+- facebook-rocksdb-v5.12.4
+
+Note: Windows rocksdb is functional, recommendation is to use vcpkg to build rocks first, and copy your rocksdb-shared.dll into the root of this project.
+
+## Testing
+
+> dub test
+
+will launch a benchmark, and should be enough to convine one of the functionality and performance.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A straightforward binding to RocksDB v5.0.1 in D-lang.
 
 You need a valid rocksdb library in the root of this project so your linker can find it.  It is recommended to use a recent version of rocksdb, tested with 
 
-- facebook-rocksdb-v5.12.4
+- facebook-rocksdb-v5.12.4 (https://github.com/facebook/rocksdb/archive/v5.12.4.tar.gz)
 
-Note: Windows rocksdb is functional, recommendation is to use vcpkg to build rocks first, and copy your rocksdb-shared.dll into the root of this project.
+Note: Windows rocksdb will work and recommendation is to use vcpkg to build rocks first, and copy your rocksdb-shared.dll into the root of the parent project.
 
 ## Testing
 

--- a/dub.json
+++ b/dub.json
@@ -6,6 +6,22 @@
     "Andrei Zbikowski <b1naryth1ef@gmail.com>"
   ],
   "targetType": "library",
-  "libraries": ["rocksdb"],
-  "lflags": ["-lrocksdb"]
+  "libs-windows-x86_64": [
+	"rocksdb-shared"
+  ],
+  "libs-windows-x86_mscoff": [
+    "rocksdb-shared"
+  ],
+  "libs-posix": [
+    "rocksdb"
+  ],
+  "lflags-windows-x86_64": [
+    "-lrocksdb-shared"
+  ],
+  "lflags-windows-x86_mscoff": [
+    "-lrocksdb-shared"
+  ],
+  "lflags-posix": [
+    "-lrocksdb"	
+  ]
 }


### PR DESCRIPTION
Add a few things to make this a smoother landing for someone using this on Windows.  Dub should be capable of handling a cross platform support without the downstream user needing to modify the dub.json.  The head scratcher for me was that the windows default rocksdb build produces a rocksdb-shared.dll (not rocksdb.dll).  So the existing dub.json won't work out of the box.  I have not tested on linux.